### PR TITLE
Harden capfeed.php and list.php

### DIFF
--- a/capfeed.php
+++ b/capfeed.php
@@ -63,14 +63,18 @@ function findLatestCapDir(string $root): ?string {
 }
 
 foreach ($SUBDIRS as $subdir) {
-    $root = $subdir === "" ? "data/publishedCap" : "data/$subdir/publishedCap";
-    $DIR = findLatestCapDir($root);
-    if ($DIR === null) continue;
+    $relRoot = $subdir === "" ? "data/publishedCap" : "data/$subdir/publishedCap";
+    $absDir = findLatestCapDir(__DIR__ . "/" . $relRoot);
+    if ($absDir === null) continue;
 
-    $FILES = scandir($DIR);
+    // Filesystem reads use the absolute path (independent of the PHP CWD);
+    // the relative form is what goes into the <id>/<link> URLs.
+    $relDir = substr($absDir, strlen(__DIR__) + 1);
+
+    $FILES = scandir($absDir);
     foreach ($FILES as $file) {
         if (preg_match("/_ALERT_/", $file) || preg_match("/_UPDATE_/", $file)) {
-            $content = file_get_contents($DIR . "/" . $file);
+            $content = file_get_contents($absDir . "/" . $file);
             $xml = new SimpleXmlElement($content);
             $senderName = (string) $xml->info->senderName;
 
@@ -78,23 +82,23 @@ foreach ($SUBDIRS as $subdir) {
                 continue;
             }
 
-            $entryUrl = htmlspecialchars($address . $DIR . "/" . $file, ENT_XML1, 'UTF-8');
+            $entryUrl = htmlspecialchars($address . $relDir . "/" . $file, ENT_XML1 | ENT_QUOTES, 'UTF-8');
             $atom .= "<entry>\n";
             $atom .= "<id>" . $entryUrl . "</id>\n";
-            $atom .= "<title>" . htmlspecialchars((string) $xml->info->event, ENT_XML1, 'UTF-8') . " for " . htmlspecialchars($xml->info->area->areaDesc, ENT_XML1, 'UTF-8') . " issued " . date('F j \a\t g:i A T', strtotime($xml->info->onset)) . " until " . date('F j \a\t g:i A T', strtotime($xml->info->expires)) . " </title>\n";
-            $atom .= "<summary>" . htmlspecialchars($xml->info->description, ENT_XML1, 'UTF-8') . "</summary>\n";
-            $atom .= "<cap:effective>" . htmlspecialchars((string) $xml->info->effective, ENT_XML1, 'UTF-8') . "</cap:effective>\n";
-            $atom .= "<cap:expires>" . htmlspecialchars((string) $xml->info->expires, ENT_XML1, 'UTF-8') . "</cap:expires>\n";
-            $atom .= "<updated>" . htmlspecialchars((string) $xml->sent, ENT_XML1, 'UTF-8') . "</updated>\n";
-            $updated = date("c", filemtime($DIR . "/" . $file));
+            $atom .= "<title>" . htmlspecialchars((string) $xml->info->event, ENT_XML1 | ENT_QUOTES, 'UTF-8') . " for " . htmlspecialchars($xml->info->area->areaDesc, ENT_XML1 | ENT_QUOTES, 'UTF-8') . " issued " . date('F j \a\t g:i A T', strtotime($xml->info->onset)) . " until " . date('F j \a\t g:i A T', strtotime($xml->info->expires)) . " </title>\n";
+            $atom .= "<summary>" . htmlspecialchars($xml->info->description, ENT_XML1 | ENT_QUOTES, 'UTF-8') . "</summary>\n";
+            $atom .= "<cap:effective>" . htmlspecialchars((string) $xml->info->effective, ENT_XML1 | ENT_QUOTES, 'UTF-8') . "</cap:effective>\n";
+            $atom .= "<cap:expires>" . htmlspecialchars((string) $xml->info->expires, ENT_XML1 | ENT_QUOTES, 'UTF-8') . "</cap:expires>\n";
+            $atom .= "<updated>" . htmlspecialchars((string) $xml->sent, ENT_XML1 | ENT_QUOTES, 'UTF-8') . "</updated>\n";
+            $updated = date("c", filemtime($absDir . "/" . $file));
             $atom .= '<link rel="related" type="application/cap+xml" href="' . $entryUrl . '"/>' . "\n";
             $atom .= "</entry>\n";
         }
     }
 }
 
-$senderNameEsc = htmlspecialchars($senderName, ENT_XML1, 'UTF-8');
-$capfeedEsc = htmlspecialchars($capfeed, ENT_XML1, 'UTF-8');
+$senderNameEsc = htmlspecialchars($senderName, ENT_XML1 | ENT_QUOTES, 'UTF-8');
+$capfeedEsc = htmlspecialchars($capfeed, ENT_XML1 | ENT_QUOTES, 'UTF-8');
 
 if ($atom === "") {
     $updated = date("c", time());
@@ -106,7 +110,7 @@ if ($atom === "") {
 <name>$senderNameEsc</name>
 </author>
 <title>There are no active watches, warnings or advisories</title>
-<link href='$capfeedEsc'/>
+<link href="$capfeedEsc"/>
 <summary>There are no active watches, warnings or advisories</summary>
 </entry>
 EOT;

--- a/capfeed.php
+++ b/capfeed.php
@@ -46,9 +46,26 @@ $address = $protocol . "://" . $host . $dir . "/";
 // Full feed URL
 $capfeed = $protocol . "://" . $host . $script_name;
 
-foreach ($SUBDIRS as $dir) {
-    $DIR = trim(shell_exec("find data/$dir/publishedCap -type d|sort -n|tail -1"));
-    if (!$DIR || !is_dir($DIR)) continue; // Skip if $DIR is empty or not a directory
+function findLatestCapDir(string $root): ?string {
+    if (!is_dir($root)) return null;
+    $latest = $root;
+    $it = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::SELF_FIRST
+    );
+    foreach ($it as $fileInfo) {
+        if ($fileInfo->isDir()) {
+            $path = $fileInfo->getPathname();
+            if (strcmp($path, $latest) > 0) $latest = $path;
+        }
+    }
+    return $latest;
+}
+
+foreach ($SUBDIRS as $subdir) {
+    $root = $subdir === "" ? "data/publishedCap" : "data/$subdir/publishedCap";
+    $DIR = findLatestCapDir($root);
+    if ($DIR === null) continue;
 
     $FILES = scandir($DIR);
     foreach ($FILES as $file) {
@@ -61,31 +78,35 @@ foreach ($SUBDIRS as $dir) {
                 continue;
             }
 
+            $entryUrl = htmlspecialchars($address . $DIR . "/" . $file, ENT_XML1, 'UTF-8');
             $atom .= "<entry>\n";
-            $atom .= "<id>$address" . $DIR . "/" . $file . "</id>\n";
-            $atom .= "<title>" . $xml->info->event . " for " . htmlspecialchars($xml->info->area->areaDesc, ENT_XML1, 'UTF-8') . " issued " . date('F j \a\t g:i A T', strtotime($xml->info->onset)) . " until " . date('F j \a\t g:i A T', strtotime($xml->info->expires)) . " </title>\n";
+            $atom .= "<id>" . $entryUrl . "</id>\n";
+            $atom .= "<title>" . htmlspecialchars((string) $xml->info->event, ENT_XML1, 'UTF-8') . " for " . htmlspecialchars($xml->info->area->areaDesc, ENT_XML1, 'UTF-8') . " issued " . date('F j \a\t g:i A T', strtotime($xml->info->onset)) . " until " . date('F j \a\t g:i A T', strtotime($xml->info->expires)) . " </title>\n";
             $atom .= "<summary>" . htmlspecialchars($xml->info->description, ENT_XML1, 'UTF-8') . "</summary>\n";
-            $atom .= "<cap:effective>" . $xml->info->effective . "</cap:effective>\n";
-            $atom .= "<cap:expires>" . $xml->info->expires . "</cap:expires>\n";
-            $atom .= "<updated>" . $xml->sent . "</updated>\n";
+            $atom .= "<cap:effective>" . htmlspecialchars((string) $xml->info->effective, ENT_XML1, 'UTF-8') . "</cap:effective>\n";
+            $atom .= "<cap:expires>" . htmlspecialchars((string) $xml->info->expires, ENT_XML1, 'UTF-8') . "</cap:expires>\n";
+            $atom .= "<updated>" . htmlspecialchars((string) $xml->sent, ENT_XML1, 'UTF-8') . "</updated>\n";
             $updated = date("c", filemtime($DIR . "/" . $file));
-            $atom .= '<link rel="related" type="application/cap+xml" href="' . $address . $DIR . "/" . $file . '"/>' . "\n";
+            $atom .= '<link rel="related" type="application/cap+xml" href="' . $entryUrl . '"/>' . "\n";
             $atom .= "</entry>\n";
         }
     }
 }
 
+$senderNameEsc = htmlspecialchars($senderName, ENT_XML1, 'UTF-8');
+$capfeedEsc = htmlspecialchars($capfeed, ENT_XML1, 'UTF-8');
+
 if ($atom === "") {
     $updated = date("c", time());
     $atom = <<<EOT
 <entry>
-<id>$capfeed</id>
+<id>$capfeedEsc</id>
 <updated>$updated</updated>
 <author>
-<name>$senderName</name>
+<name>$senderNameEsc</name>
 </author>
 <title>There are no active watches, warnings or advisories</title>
-<link href='$capfeed'/>
+<link href='$capfeedEsc'/>
 <summary>There are no active watches, warnings or advisories</summary>
 </entry>
 EOT;
@@ -97,27 +118,27 @@ echo <<<EOT
 <!--?xml-stylesheet href='capatom.xsl' type='text/xsl'?-->
 <!--
   This atom/xml feed is an index to active advisories, watches and warnings
-  issued by the $senderName. This index file
+  issued by the $senderNameEsc. This index file
   is not the complete Common Alerting Protocol (CAP) alert message. To obtain
   the complete CAP alert, please follow the links for each entry in this index.
   Not all information in the CAP message is contained in this index of active
   alerts.
 -->
 
-<feed 
+<feed
   xmlns="http://www.w3.org/2005/Atom"
   xmlns:cap="urn:oasis:names:tc:emergency:cap:1.2"
   xmlns:ha="http://www.alerting.net/namespace/index_1.0">
 
-  <link href="$capfeed" rel="self"/>
-  <rights> Copyright, $senderName. Licensed under CC BY 4.0 </rights>
-  <id>$capfeed</id>
-  <generator>$senderName</generator>
+  <link href="$capfeedEsc" rel="self"/>
+  <rights> Copyright, $senderNameEsc. Licensed under CC BY 4.0 </rights>
+  <id>$capfeedEsc</id>
+  <generator>$senderNameEsc</generator>
   <updated>$updated</updated>
   <author>
-     <name>$senderName</name>
+     <name>$senderNameEsc</name>
   </author>
-  <title>Current Watches, Warnings and Advisories Issued by $senderName</title>
+  <title>Current Watches, Warnings and Advisories Issued by $senderNameEsc</title>
 $atom
 </feed>
 EOT;

--- a/list.php
+++ b/list.php
@@ -47,13 +47,17 @@ function findLatestCapDir(string $root): ?string {
 }
 
 foreach ($SUBDIRS as $DIR) {
-  $root = $DIR === "" ? "data/publishedCap" : "data/$DIR/publishedCap";
-  $latest = findLatestCapDir($root);
-  if ($latest === null) continue;
+  $relRoot = $DIR === "" ? "data/publishedCap" : "data/$DIR/publishedCap";
+  $absLatest = findLatestCapDir(__DIR__ . "/" . $relRoot);
+  if ($absLatest === null) continue;
 
-  foreach (scandir($latest) as $file) {
+  // Keep the response paths relative to the document root, but do all
+  // filesystem reads against the absolute path (independent of the PHP CWD).
+  $relLatest = substr($absLatest, strlen(__DIR__) + 1);
+
+  foreach (scandir($absLatest) as $file) {
     if (preg_match("/_ALERT_/", $file) || preg_match("/_UPDATE_/", $file)) {
-      $capfiles[] = $latest . "/" . $file;
+      $capfiles[] = $relLatest . "/" . $file;
     }
   }
 }

--- a/list.php
+++ b/list.php
@@ -1,11 +1,11 @@
 <?php
 
 $capfiles = [];
+$basePath = __DIR__ . "/data";
 
-$DIRS = filter_input(INPUT_GET, 'dir', FILTER_SANITIZE_SPECIAL_CHARS);
+$DIRS = filter_input(INPUT_GET, 'dir');
 
 if (!$DIRS) {
-  $basePath = __DIR__ . "/data";
   $SUBDIRS = [];
   if (is_dir("$basePath/publishedCap")) {
     // If "data/publishedCap" exists, just use that
@@ -20,17 +20,40 @@ if (!$DIRS) {
     }
   }
 } else {
-  $SUBDIRS = explode(',', $DIRS);
+  // Validate user-supplied dir against a strict whitelist (prevents path traversal)
+  $SUBDIRS = [];
+  foreach (explode(',', $DIRS) as $d) {
+    $d = trim($d);
+    if ($d === "" || !preg_match('/^[A-Za-z0-9_-]+$/', $d)) continue;
+    if (!is_dir("$basePath/$d/publishedCap")) continue;
+    $SUBDIRS[] = $d;
+  }
+}
+
+function findLatestCapDir(string $root): ?string {
+  if (!is_dir($root)) return null;
+  $latest = $root;
+  $it = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS),
+    RecursiveIteratorIterator::SELF_FIRST
+  );
+  foreach ($it as $fileInfo) {
+    if ($fileInfo->isDir()) {
+      $path = $fileInfo->getPathname();
+      if (strcmp($path, $latest) > 0) $latest = $path;
+    }
+  }
+  return $latest;
 }
 
 foreach ($SUBDIRS as $DIR) {
-  $DIR = trim(`find data/$DIR/publishedCap -type d|sort -n|tail -1`);
-  if (!$DIR || !is_dir($DIR)) continue;
+  $root = $DIR === "" ? "data/publishedCap" : "data/$DIR/publishedCap";
+  $latest = findLatestCapDir($root);
+  if ($latest === null) continue;
 
-  $FILES = scandir($DIR);
-  foreach ($FILES as $file) {
+  foreach (scandir($latest) as $file) {
     if (preg_match("/_ALERT_/", $file) || preg_match("/_UPDATE_/", $file)) {
-      $capfiles[] = $DIR . "/" . $file;
+      $capfiles[] = $latest . "/" . $file;
     }
   }
 }


### PR DESCRIPTION
## Summary
- **list.php**: auto-discover `data/*/publishedCap` when no `?dir=` is given (the reported bug on alert.meteo.kg), return `[]` instead of `null` for empty results, and validate `?dir=` against `^[A-Za-z0-9_-]+$` to close a shell-injection / path-traversal hole.
- **capfeed.php**: always append the slash after the directory component of `\$address` so entry URLs are well-formed at document root (fixes missing `/` after the domain), XML-escape all output fields that come from CAP payloads or the `Host` header, and replace the `find` shell-out with `RecursiveDirectoryIterator`.
- Both files: drop the shell-out entirely in favor of native PHP directory traversal. Loop-variable rename in capfeed.php to avoid shadowing the URL-path `\$dir` computed earlier.

## Test plan
- [x] CI workflow added in master now gates merges by linting all PHP with `php:7.2-cli`, building the image, and smoke-testing endpoints against CAP fixtures (flat + subdir layouts, auto-discovery, `?dir=` single/multi, and `?dir=../evil` rejection).
- [ ] Confirm the workflow's smoke tests pass on this PR.
- [ ] Spot-check the resulting `pr-<N>` image from Docker Hub / GHCR against a real `data/` mount before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)